### PR TITLE
Add header-based PAT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,21 @@ Here's a complete example of setting up multi-user authentication with streamabl
 }
 ```
 
+**Server/Data Center with Separate Jira/Confluence Tokens**
+```json
+{
+  "mcpServers": {
+    "mcp-atlassian-service": {
+      "url": "http://localhost:9000/mcp",
+      "headers": {
+        "X-Jira": "<JIRA_PAT>",
+        "X-Confluence": "<CONFLUENCE_PAT>"
+      }
+    }
+  }
+}
+```
+
 4. Required environment variables in `.env`:
    ```bash
    JIRA_URL=https://your-company.atlassian.net

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Here's a complete example of setting up multi-user authentication with streamabl
 
 > [!NOTE]
 > - The server should have its own fallback authentication configured (e.g., via environment variables for API token, PAT, or its own OAuth setup using --oauth-setup). This is used if a request doesn't include user-specific authentication.
+> - When sending tokens via `X-Jira` and `X-Confluence` headers, only `JIRA_URL` and `CONFLUENCE_URL` need to be set for the server.
 > - **OAuth**: Each user needs their own OAuth access token from your Atlassian OAuth app.
 > - **PAT**: Each user provides their own Personal Access Token.
 > - The server will use the user's token for API calls when provided, falling back to server auth if not

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -51,14 +51,20 @@ class ConfluenceConfig:
         return self.ssl_verify
 
     @classmethod
-    def from_env(cls) -> "ConfluenceConfig":
+    def from_env(cls, allow_missing_auth: bool = False) -> "ConfluenceConfig":
         """Create configuration from environment variables.
+
+        Args:
+            allow_missing_auth: When ``True`` do not raise an error if
+                authentication credentials are missing. This supports
+                scenarios where tokens are provided via request headers.
 
         Returns:
             ConfluenceConfig with values from environment variables
 
         Raises:
-            ValueError: If any required environment variable is missing
+            ValueError: If any required environment variable is missing and
+                ``allow_missing_auth`` is ``False``
         """
         url = os.getenv("CONFLUENCE_URL")
         if not url:
@@ -83,8 +89,13 @@ class ConfluenceConfig:
         elif is_cloud:
             if username and api_token:
                 auth_type = "basic"
+            elif allow_missing_auth:
+                auth_type = "basic"
             else:
-                error_msg = "Cloud authentication requires CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN, or OAuth configuration"
+                error_msg = (
+                    "Cloud authentication requires CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN, "
+                    "or OAuth configuration"
+                )
                 raise ValueError(error_msg)
         else:  # Server/Data Center
             if personal_token:
@@ -92,8 +103,13 @@ class ConfluenceConfig:
             elif username and api_token:
                 # Allow basic auth for Server/DC too
                 auth_type = "basic"
+            elif allow_missing_auth:
+                auth_type = "token"
             else:
-                error_msg = "Server/Data Center authentication requires CONFLUENCE_PERSONAL_TOKEN or CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN"
+                error_msg = (
+                    "Server/Data Center authentication requires CONFLUENCE_PERSONAL_TOKEN or "
+                    "CONFLUENCE_USERNAME and CONFLUENCE_API_TOKEN"
+                )
                 raise ValueError(error_msg)
 
         # SSL verification (for Server/DC)

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -51,14 +51,20 @@ class JiraConfig:
         return self.ssl_verify
 
     @classmethod
-    def from_env(cls) -> "JiraConfig":
+    def from_env(cls, allow_missing_auth: bool = False) -> "JiraConfig":
         """Create configuration from environment variables.
+
+        Args:
+            allow_missing_auth: When ``True`` do not raise an error if
+                authentication credentials are absent. This is useful when
+                per-request tokens will be provided via request headers.
 
         Returns:
             JiraConfig with values from environment variables
 
         Raises:
             ValueError: If required environment variables are missing or invalid
+                and ``allow_missing_auth`` is ``False``
         """
         url = os.getenv("JIRA_URL")
         if not url:
@@ -83,8 +89,13 @@ class JiraConfig:
         elif is_cloud:
             if username and api_token:
                 auth_type = "basic"
+            elif allow_missing_auth:
+                auth_type = "basic"
             else:
-                error_msg = "Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, or OAuth configuration"
+                error_msg = (
+                    "Cloud authentication requires JIRA_USERNAME and JIRA_API_TOKEN, "
+                    "or OAuth configuration"
+                )
                 raise ValueError(error_msg)
         else:  # Server/Data Center
             if personal_token:
@@ -92,8 +103,13 @@ class JiraConfig:
             elif username and api_token:
                 # Allow basic auth for Server/DC too
                 auth_type = "basic"
+            elif allow_missing_auth:
+                auth_type = "pat"
             else:
-                error_msg = "Server/Data Center authentication requires JIRA_PERSONAL_TOKEN or JIRA_USERNAME and JIRA_API_TOKEN"
+                error_msg = (
+                    "Server/Data Center authentication requires JIRA_PERSONAL_TOKEN or "
+                    "JIRA_USERNAME and JIRA_API_TOKEN"
+                )
                 raise ValueError(error_msg)
 
         # SSL verification (for Server/DC)

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -158,6 +158,43 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
             return request.state.jira_fetcher
         user_auth_type = getattr(request.state, "user_atlassian_auth_type", None)
         logger.debug(f"get_jira_fetcher: User auth type: {user_auth_type}")
+        user_jira_pat = getattr(request.state, "user_jira_pat", None)
+        if user_jira_pat:
+            credentials = {
+                "user_email_context": None,
+                "personal_access_token": user_jira_pat,
+            }
+            lifespan_ctx_dict = ctx.request_context.lifespan_context  # type: ignore
+            app_lifespan_ctx: MainAppContext | None = (
+                lifespan_ctx_dict.get("app_lifespan_context")
+                if isinstance(lifespan_ctx_dict, dict)
+                else None
+            )
+            if not app_lifespan_ctx or not app_lifespan_ctx.full_jira_config:
+                raise ValueError(
+                    "Jira global configuration (URL, SSL) is not available from lifespan context."
+                )
+            logger.info("Creating user-specific JiraFetcher (token header)")
+            user_specific_config = _create_user_config_for_fetcher(
+                base_config=app_lifespan_ctx.full_jira_config,
+                auth_type="pat",
+                credentials=credentials,
+            )
+            try:
+                user_jira_fetcher = JiraFetcher(config=user_specific_config)
+                current_user_id = user_jira_fetcher.get_current_user_account_id()
+                logger.debug(
+                    f"get_jira_fetcher: Validated Jira token for user ID: {current_user_id}"
+                )
+                request.state.jira_fetcher = user_jira_fetcher
+                return user_jira_fetcher
+            except Exception as e:
+                logger.error(
+                    f"get_jira_fetcher: Failed to create/validate user-specific JiraFetcher: {e}",
+                    exc_info=True,
+                )
+                raise ValueError(f"Invalid user Jira token or configuration: {e}")
+
         # If OAuth or PAT token is present, create user-specific fetcher
         if user_auth_type in ["oauth", "pat"] and hasattr(
             request.state, "user_atlassian_token"
@@ -263,6 +300,56 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
             return request.state.confluence_fetcher
         user_auth_type = getattr(request.state, "user_atlassian_auth_type", None)
         logger.debug(f"get_confluence_fetcher: User auth type: {user_auth_type}")
+
+        user_confluence_pat = getattr(request.state, "user_confluence_pat", None)
+        if user_confluence_pat:
+            credentials = {
+                "user_email_context": None,
+                "personal_access_token": user_confluence_pat,
+            }
+            lifespan_ctx_dict = ctx.request_context.lifespan_context  # type: ignore
+            app_lifespan_ctx: MainAppContext | None = (
+                lifespan_ctx_dict.get("app_lifespan_context")
+                if isinstance(lifespan_ctx_dict, dict)
+                else None
+            )
+            if not app_lifespan_ctx or not app_lifespan_ctx.full_confluence_config:
+                raise ValueError(
+                    "Confluence global configuration (URL, SSL) is not available from lifespan context."
+                )
+            logger.info("Creating user-specific ConfluenceFetcher (token header)")
+            user_specific_config = _create_user_config_for_fetcher(
+                base_config=app_lifespan_ctx.full_confluence_config,
+                auth_type="pat",
+                credentials=credentials,
+            )
+            try:
+                user_confluence_fetcher = ConfluenceFetcher(config=user_specific_config)
+                current_user_data = user_confluence_fetcher.get_current_user_info()
+                derived_email = (
+                    current_user_data.get("email") if isinstance(current_user_data, dict) else None
+                )
+                display_name = (
+                    current_user_data.get("displayName") if isinstance(current_user_data, dict) else None
+                )
+                logger.debug(
+                    f"get_confluence_fetcher: Validated Confluence token. User context: Email='{derived_email}', DisplayName='{display_name}'"
+                )
+                request.state.confluence_fetcher = user_confluence_fetcher
+                if (
+                    derived_email
+                    and current_user_data
+                    and isinstance(current_user_data, dict)
+                    and current_user_data.get("email")
+                ):
+                    request.state.user_atlassian_email = current_user_data["email"]
+                return user_confluence_fetcher
+            except Exception as e:
+                logger.error(
+                    f"get_confluence_fetcher: Failed to create/validate user-specific ConfluenceFetcher: {e}"
+                )
+                raise ValueError(f"Invalid user Confluence token or configuration: {e}")
+
         if user_auth_type in ["oauth", "pat"] and hasattr(
             request.state, "user_atlassian_token"
         ):

--- a/src/mcp_atlassian/servers/dependencies.py
+++ b/src/mcp_atlassian/servers/dependencies.py
@@ -257,7 +257,11 @@ async def get_jira_fetcher(ctx: Context) -> JiraFetcher:
         if isinstance(lifespan_ctx_dict_global, dict)
         else None
     )
-    if app_lifespan_ctx_global and app_lifespan_ctx_global.full_jira_config:
+    if (
+        app_lifespan_ctx_global
+        and app_lifespan_ctx_global.full_jira_config
+        and app_lifespan_ctx_global.full_jira_config.is_auth_configured()
+    ):
         logger.debug(
             "get_jira_fetcher: Using global JiraFetcher from lifespan_context. "
             f"Global config auth_type: {app_lifespan_ctx_global.full_jira_config.auth_type}"
@@ -426,7 +430,11 @@ async def get_confluence_fetcher(ctx: Context) -> ConfluenceFetcher:
         if isinstance(lifespan_ctx_dict_global, dict)
         else None
     )
-    if app_lifespan_ctx_global and app_lifespan_ctx_global.full_confluence_config:
+    if (
+        app_lifespan_ctx_global
+        and app_lifespan_ctx_global.full_confluence_config
+        and app_lifespan_ctx_global.full_confluence_config.is_auth_configured()
+    ):
         logger.debug(
             "get_confluence_fetcher: Using global ConfluenceFetcher from lifespan_context. "
             f"Global config auth_type: {app_lifespan_ctx_global.full_confluence_config.auth_type}"

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -48,14 +48,14 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
     if services.get("jira"):
         try:
             jira_config = JiraConfig.from_env()
+            loaded_jira_config = jira_config
             if jira_config.is_auth_configured():
-                loaded_jira_config = jira_config
                 logger.info(
                     "Jira configuration loaded and authentication is configured."
                 )
             else:
-                logger.warning(
-                    "Jira URL found, but authentication is not fully configured. Jira tools will be unavailable."
+                logger.info(
+                    "Jira configuration loaded without authentication; expecting request-specific tokens"
                 )
         except Exception as e:
             logger.error(f"Failed to load Jira configuration: {e}", exc_info=True)
@@ -63,14 +63,14 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
     if services.get("confluence"):
         try:
             confluence_config = ConfluenceConfig.from_env()
+            loaded_confluence_config = confluence_config
             if confluence_config.is_auth_configured():
-                loaded_confluence_config = confluence_config
                 logger.info(
                     "Confluence configuration loaded and authentication is configured."
                 )
             else:
-                logger.warning(
-                    "Confluence URL found, but authentication is not fully configured. Confluence tools will be unavailable."
+                logger.info(
+                    "Confluence configuration loaded without authentication; expecting request-specific tokens"
                 )
         except Exception as e:
             logger.error(f"Failed to load Confluence configuration: {e}", exc_info=True)

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -281,6 +281,21 @@ class UserTokenMiddleware(BaseHTTPMiddleware):
                 logger.debug(
                     f"No Authorization header provided for {request.url.path}. Will proceed with global/fallback server configuration if applicable."
                 )
+
+            jira_header = request.headers.get("X-Jira")
+            confluence_header = request.headers.get("X-Confluence")
+            if jira_header:
+                masked = mask_sensitive(jira_header)
+                logger.debug(
+                    f"UserTokenMiddleware.dispatch: X-Jira header detected (masked): {masked}"
+                )
+                request.state.user_jira_pat = jira_header.strip()
+            if confluence_header:
+                masked = mask_sensitive(confluence_header)
+                logger.debug(
+                    f"UserTokenMiddleware.dispatch: X-Confluence header detected (masked): {masked}"
+                )
+                request.state.user_confluence_pat = confluence_header.strip()
         response = await call_next(request)
         logger.debug(
             f"UserTokenMiddleware.dispatch: EXITED for request path='{request.url.path}'"

--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -47,7 +47,7 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
 
     if services.get("jira"):
         try:
-            jira_config = JiraConfig.from_env()
+            jira_config = JiraConfig.from_env(allow_missing_auth=True)
             loaded_jira_config = jira_config
             if jira_config.is_auth_configured():
                 logger.info(
@@ -62,7 +62,7 @@ async def main_lifespan(app: FastMCP[MainAppContext]) -> AsyncIterator[dict]:
 
     if services.get("confluence"):
         try:
-            confluence_config = ConfluenceConfig.from_env()
+            confluence_config = ConfluenceConfig.from_env(allow_missing_auth=True)
             loaded_confluence_config = confluence_config
             if confluence_config.is_auth_configured():
                 logger.info(

--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("mcp-atlassian.utils.environment")
 def get_available_services() -> dict[str, bool | None]:
     """Determine which services are available based on environment variables."""
     confluence_url = os.getenv("CONFLUENCE_URL")
-    confluence_is_setup = False
+    confluence_is_setup = bool(confluence_url)
     if confluence_url:
         is_cloud = is_atlassian_cloud_url(confluence_url)
 
@@ -48,10 +48,17 @@ def get_available_services() -> dict[str, bool | None]:
                 logger.info(
                     "Using Confluence Server/Data Center authentication (PAT or Basic Auth)"
                 )
-    # If confluence_url is not set, confluence_is_setup remains False
+            else:
+                logger.info(
+                    "Confluence URL found without auth credentials; expecting per-request tokens"
+                )
+    else:
+        logger.info(
+            "Confluence is not configured or required environment variables are missing."
+        )
 
     jira_url = os.getenv("JIRA_URL")
-    jira_is_setup = False
+    jira_is_setup = bool(jira_url)
     if jira_url:
         is_cloud = is_atlassian_cloud_url(jira_url)
 
@@ -86,13 +93,11 @@ def get_available_services() -> dict[str, bool | None]:
                 logger.info(
                     "Using Jira Server/Data Center authentication (PAT or Basic Auth)"
                 )
-    # If jira_url is not set, jira_is_setup remains False
-
-    if not confluence_is_setup:
-        logger.info(
-            "Confluence is not configured or required environment variables are missing."
-        )
-    if not jira_is_setup:
+            else:
+                logger.info(
+                    "Jira URL found without auth credentials; expecting per-request tokens"
+                )
+    else:
         logger.info(
             "Jira is not configured or required environment variables are missing."
         )

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -73,6 +73,21 @@ def test_from_env_missing_server_auth():
             ConfluenceConfig.from_env()
 
 
+def test_from_env_allow_missing_server_auth():
+    """Server URL without credentials should succeed when allow_missing_auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+        },
+        clear=True,
+    ):
+        cfg = ConfluenceConfig.from_env(allow_missing_auth=True)
+        assert cfg.url == "https://confluence.example.com"
+        assert cfg.auth_type == "token"
+        assert cfg.personal_token is None
+
+
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
     # Arrange & Act - Cloud URL

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -95,6 +95,21 @@ def test_from_env_missing_server_auth():
             JiraConfig.from_env()
 
 
+def test_from_env_allow_missing_server_auth():
+    """Server URL without credentials should succeed when allow_missing_auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+        },
+        clear=True,
+    ):
+        cfg = JiraConfig.from_env(allow_missing_auth=True)
+        assert cfg.url == "https://jira.example.com"
+        assert cfg.auth_type == "pat"
+        assert cfg.personal_token is None
+
+
 def test_is_cloud():
     """Test that is_cloud property returns correct value."""
     # Arrange & Act - Cloud URL

--- a/tests/unit/servers/test_confluence_server.py
+++ b/tests/unit/servers/test_confluence_server.py
@@ -552,6 +552,45 @@ async def test_get_page_with_user_specific_fetcher_in_state(
 
 
 @pytest.mark.anyio
+async def test_get_page_with_header_token(
+    test_confluence_mcp, mock_confluence_fetcher
+):
+    """Token provided via X-Confluence header should create user-specific fetcher."""
+    _mock_request = MagicMock(spec=Request)
+    _mock_request.state = MagicMock()
+    _mock_request.state.confluence_fetcher = None
+    _mock_request.state.user_confluence_pat = "header_token"
+
+    from src.mcp_atlassian.servers.dependencies import (
+        get_confluence_fetcher as get_confluence_fetcher_real,
+    )
+
+    with (
+        patch(
+            "src.mcp_atlassian.servers.dependencies.get_http_request",
+            return_value=_mock_request,
+        ) as mock_get_http,
+        patch(
+            "src.mcp_atlassian.servers.dependencies.ConfluenceFetcher",
+            return_value=mock_confluence_fetcher,
+        ) as mock_fetcher_cls,
+        patch(
+            "src.mcp_atlassian.servers.confluence.get_confluence_fetcher",
+            side_effect=AsyncMock(wraps=get_confluence_fetcher_real),
+        ),
+    ):
+        async with Client(transport=FastMCPTransport(test_confluence_mcp)) as client_instance:
+            await client_instance.call_tool(
+                "confluence_get_page",
+                {"page_id": "123"},
+            )
+
+    mock_get_http.assert_called()
+    called_config = mock_fetcher_cls.call_args.kwargs["config"]
+    assert called_config.personal_token == "header_token"
+
+
+@pytest.mark.anyio
 async def test_get_page_by_title_and_space_key(client, mock_confluence_fetcher):
     """Test get_page tool with title and space_key lookup."""
     mock_page = MagicMock(spec=ConfluencePage)

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -635,6 +635,45 @@ async def test_get_issue_with_user_specific_fetcher_in_state(
 
 
 @pytest.mark.anyio
+async def test_get_issue_with_header_token(
+    test_jira_mcp, mock_jira_fetcher, mock_base_jira_config
+):
+    """Token provided via X-Jira header should create user-specific fetcher."""
+    _mock_request = MagicMock(spec=Request)
+    _mock_request.state = MagicMock()
+    _mock_request.state.jira_fetcher = None
+    _mock_request.state.user_jira_pat = "header_token"
+
+    from src.mcp_atlassian.servers.dependencies import (
+        get_jira_fetcher as get_jira_fetcher_real,
+    )
+
+    with (
+        patch(
+            "src.mcp_atlassian.servers.dependencies.get_http_request",
+            return_value=_mock_request,
+        ) as mock_get_http,
+        patch(
+            "src.mcp_atlassian.servers.dependencies.JiraFetcher",
+            return_value=mock_jira_fetcher,
+        ) as mock_fetcher_cls,
+        patch(
+            "src.mcp_atlassian.servers.jira.get_jira_fetcher",
+            side_effect=AsyncMock(wraps=get_jira_fetcher_real),
+        ),
+    ):
+        async with Client(transport=FastMCPTransport(test_jira_mcp)) as client_instance:
+            await client_instance.call_tool(
+                "jira_get_issue",
+                {"issue_key": "HDR-1", "fields": "summary,status"},
+            )
+
+    mock_get_http.assert_called()
+    called_config = mock_fetcher_cls.call_args.kwargs["config"]
+    assert called_config.personal_token == "header_token"
+
+
+@pytest.mark.anyio
 async def test_get_project_versions_tool(jira_client, mock_jira_fetcher):
     """Test the jira_get_project_versions tool returns simplified version list."""
     # Prepare mock raw versions


### PR DESCRIPTION
## Summary
- support `X-Jira` and `X-Confluence` headers in middleware
- use header tokens in Jira and Confluence fetchers
- add regression tests for new header logic
- document header PAT example for Data Center deployments

## Testing
- `uv sync --frozen --all-extras --dev` *(failed: command produced no output)*
- `pre-commit install` *(failed: command not found)*
- `pre-commit run --all-files` *(failed: command not found)*
- `uv run pytest` *(failed: network errors during tests)*


------
https://chatgpt.com/codex/tasks/task_e_684a4cf7246c833087ef0afe6727fbce